### PR TITLE
Update to support cslint 1.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,22 +38,20 @@ module.exports = function lessReporter(importsFilter) {
     var sourceMap = new SourceMapConsumer(file.sourceMap);
 
     // resolve original lines and filter to relevant files
-    var mappedResults = file.csslint.results.map(function (result) {
-      var message = result.error;
-
-      if (!message.line || message.rollup) {
+    var mappedResults = file.csslint.report.messages.map(function (result) {
+      if (!result.line || result.rollup) {
         result.file = origFilePath;
         return result;
       }
 
       var origPos = sourceMap.originalPositionFor({
-        line: message.line,
-        column: message.col
+        line: result.line,
+        column: result.col
       });
 
       if (origPos.source) {
-        result.error.line = origPos.line;
-        result.error.col = origPos.column;
+        result.line = origPos.line;
+        result.col = origPos.column;
         result.file = path.resolve(path.join(file.base, origPos.source));
       }
 
@@ -69,15 +67,14 @@ module.exports = function lessReporter(importsFilter) {
 
     // print errors
     mappedResults.forEach(function (result) {
-      var message = result.error;
-      allErrors.push(message);
+      allErrors.push(result);
 
       var location = '';
-      if (typeof message.line != 'undefined') {
+      if (typeof result.line != 'undefined') {
         location =
-          colors.magenta(message.line) +
+          colors.magenta(result.line) +
           ',' +
-          colors.magenta(message.col);
+          colors.magenta(result.col);
       }
 
       gutil.log(
@@ -87,17 +84,17 @@ module.exports = function lessReporter(importsFilter) {
         ':' +
         location +
         ' (' +
-        message.rule.id +
+        result.rule.id +
         ') ');
 
       gutil.log(
-        message.type.toUpperCase() +
+        result.type.toUpperCase() +
         ': ' +
-        message.message +
+        result.message +
         ' ' +
-        message.rule.desc +
+        result.rule.desc +
         ' Browsers: ' +
-        message.rule.browsers);
+        result.rule.browsers);
     });
 
     callback(null, file);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "gulp": "^3.9.0",
-    "gulp-csslint": "^0.1.5",
+    "gulp-csslint": "^1.0.0",
     "gulp-eslint": "^0.14.0",
     "gulp-if": "^1.2.5",
     "gulp-less": "^3.0.3",


### PR DESCRIPTION
The csslint error report format changed in v1 which this fixes.

I'm getting an eslint error on the first line despite not changing anything there. Since this is such an old version I'm not sure what the correct rule settings are to fix it. Probably best to just update the dependencies at this point.
